### PR TITLE
feat: creadas migraciones de BD

### DIFF
--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -21,12 +21,6 @@ return new class extends Migration
             $table->timestamps();
         });
 
-        Schema::create('password_reset_tokens', function (Blueprint $table) {
-            $table->string('email')->primary();
-            $table->string('token');
-            $table->timestamp('created_at')->nullable();
-        });
-
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
@@ -43,7 +37,6 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('users');
-        Schema::dropIfExists('password_reset_tokens');
         Schema::dropIfExists('sessions');
     }
 };

--- a/database/migrations/2025_05_17_041948_create_empresas_tables.php
+++ b/database/migrations/2025_05_17_041948_create_empresas_tables.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tipo_empresas', function (Blueprint $table) {
+            $table->id('tipo_empresa_id')->autoIncrement();
+            $table->string('nombre');
+            $table->string('descripcion')->nullable();
+            $table->boolean('habilitada')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('empresas', function (Blueprint $table) {
+            $table->id('empresa_id')->autoIncrement();
+            $table->string('abreviatura_empresa')->unique();
+            $table->string('nombre_empresa')->unique();
+            $table->string('codigo_donante');
+            $table->string('tipo_cooperacion');
+            $table->string('tipo_relacion');
+            $table->string('direccion');
+            $table->enum('estado', ['activo', 'inactivo'])->default('activo');
+            $table->foreignId('tipo_empresa_id')->constrained('tipo_empresas', 'tipo_empresa_id')->onDelete('cascade');
+            $table->boolean('habilitada')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('empresas');
+        Schema::dropIfExists('tipo_empresas');
+    }
+};

--- a/database/migrations/2025_05_17_043145_create_convenios_tables.php
+++ b/database/migrations/2025_05_17_043145_create_convenios_tables.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('convenios', function (Blueprint $table) {
+            $table->id('convenio_id');
+            $table->foreignId('empresa_id')->constrained('empresas', 'empresa_id')->onDelete('cascade');
+            $table->enum('sede', ['San Salvador', 'San Miguel', 'Santa Ana'])->default('San Salvador');
+            $table->string('nombre_contacto');
+            $table->string('telefono_contacto');
+            $table->string('correo_contacto');
+            $table->enum('estado', ['activo', 'finalizado'])->default('activo');
+            $table->string('tipo_convenio');
+            $table->date('fecha_inicio');
+            $table->date('fecha_fin')->nullable();
+            $table->string('convenio_detalle');
+            $table->boolean('convenio_respaldado')->default(true);
+            $table->boolean('estado_evidencia')->default(false);
+            $table->boolean('habilitado')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('convenios');
+    }
+};

--- a/database/migrations/2025_05_17_044258_create_archivos_evidencia_table.php
+++ b/database/migrations/2025_05_17_044258_create_archivos_evidencia_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('archivos_evidencia', function (Blueprint $table) {
+            $table->id('archivo_id');
+            $table->foreignId('convenio_id')->constrained('convenios', 'convenio_id')->onDelete('cascade');
+            $table->string('nombre_archivo');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('archivos_evidencia');
+    }
+};


### PR DESCRIPTION
This pull request introduces several changes to database migrations, focusing on restructuring existing tables and adding new ones to support a more robust data model. The most important changes include removing the `password_reset_tokens` table, creating new tables for managing companies (`empresas`), agreements (`convenios`), and evidence files (`archivos_evidencia`).

### Removal of existing table:
* The `password_reset_tokens` table was removed, along with its creation and deletion logic in the `0001_01_01_000000_create_users_table.php` migration. [[1]](diffhunk://#diff-cdba02318dca2b6013d11b385bfe12d51798f22be578484abb12c6d1782373d0L24-L29) [[2]](diffhunk://#diff-cdba02318dca2b6013d11b385bfe12d51798f22be578484abb12c6d1782373d0L46)

### Addition of new tables:
* A new migration (`2025_05_17_041948_create_empresas_tables.php`) was added to create `tipo_empresas` and `empresas` tables, which define company types and company details, respectively. These include fields for company names, relationships, and states.
* A new migration (`2025_05_17_043145_create_convenios_tables.php`) was added to create the `convenios` table, which manages agreements with companies, including details such as contact information, agreement type, and duration.
* A new migration (`2025_05_17_044258_create_archivos_evidencia_table.php`) was added to create the `archivos_evidencia` table, which stores evidence files associated with agreements.